### PR TITLE
Skip buttons when filling login/password

### DIFF
--- a/popup.js
+++ b/popup.js
@@ -838,7 +838,8 @@ function fillPassword() {
             "      var input = inputs[j];                                                        " +
             "      if (input.type.toLowerCase() === 'password') {                                " +
             "        input.value = decodeURIComponent(\"" + encodeURIComponent(password) + "\"); " +
-            "      } else if (input.name.toLowerCase().match(/login|username|email|user/)) {     " +
+            "      } else if (input.name.toLowerCase().match(/login|username|email|user/)        " +
+            "                 && input.type.toLowerCase().match(/text|email|tel/)) {             " +
             "        input.value = decodeURIComponent(\"" + encodeURIComponent(username) + "\"); " +
             "      }                                                                             " +
             "    }                                                                               " +


### PR DESCRIPTION
Some login forms have submits/buttons named 'login'. Avoid replacing the values (labels) of those buttons with the login.

Happens for example on https://www.njumobile.pl/logowanie