### PR TITLE
Store website parameters in synced storage

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -8,7 +8,8 @@
     "64": "icon_64.png"
   },
   "permissions": [
-    "activeTab"
+    "activeTab",
+    "storage"
   ],
   "browser_action": {
       "default_title": "CryptoPass",

--- a/popup.html
+++ b/popup.html
@@ -10,6 +10,7 @@
 </head> 
 <body> 
   <form id="main-form"> 
+    <input type="hidden" id="original_url" value="">
     <table> 
       <tr> 
         <td class="label">Secret</td> 


### PR DESCRIPTION
Store website parameters (username, url, length) in synced storage,
associated with the original website domain when generating the
password, and restore them when opening CryptoPass afterwards. This
saves user from having to remember/retype parameter changes every time
a particular website is visited.
